### PR TITLE
Allow running tests with count > 1

### DIFF
--- a/utils/lorem_test.go
+++ b/utils/lorem_test.go
@@ -1,25 +1,27 @@
 package utils
 
 import (
+	"math/rand"
 	"testing"
 )
 
 func TestLorem(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		want    string
 		wantErr bool
 	}{
-		// WARNING: If you add tests, you must add them after those that are already there, otherwise, all results will be changed.
-		{"Word", "expedita", false},
-		{"1", "hac", false},
-		{"Sentence", "Laudes en sequatur aer deo vos.", false},
-		{"Url", "http://www.dicamfactis.net/integer", false},
-		{"EMail", "dicentium@montiumita.org", false},
+		{"Word", "araneae", false},
+		{"1", "araneae", false},
+		{"Sentence", "Fac vel varias vim, cor munerum traiecta.", false},
+		{"Url", "http://www.diuvi.com/curam/beata.html", false},
+		{"EMail", "ardentius@curainest.net", false},
 		{"Anything", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			rand.Seed(0)
 			kind, _ := GetLoremKind(tt.name)
 			got, err := Lorem(kind)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
Lorem would fail because the RNG wasn't reseeded
```
jduchesne@wks-000685:~/repos/gotemplate$ go test ./... -count=100
ok      github.com/coveooss/gotemplate/v3       8.961s
ok      github.com/coveooss/gotemplate/v3/collections   0.274s
ok      github.com/coveooss/gotemplate/v3/collections/implementation    0.646s
ok      github.com/coveooss/gotemplate/v3/collections/tests     0.112s
ok      github.com/coveooss/gotemplate/v3/errors        0.083s
ok      github.com/coveooss/gotemplate/v3/hcl   0.862s
ok      github.com/coveooss/gotemplate/v3/json  0.776s
ok      github.com/coveooss/gotemplate/v3/template      31.391s
ok      github.com/coveooss/gotemplate/v3/utils 0.154s
ok      github.com/coveooss/gotemplate/v3/xml   0.685s
ok      github.com/coveooss/gotemplate/v3/yaml  0.717s
```