### PR TITLE
Change pause statements

### DIFF
--- a/docs_tests/advanced_features/pausing_processing.md
+++ b/docs_tests/advanced_features/pausing_processing.md
@@ -5,15 +5,15 @@ You can pause gotemplate's or razor processing with the following comments:
 {{ add 4 5 }}
 @(4+5)
 
-# pause-gotemplate!
+# gotemplate-pause!
 {{ add 4 5 }}
 @(4+5)
-# resume-gotemplate!
+# gotemplate-resume!
 
-# pause-razor!
+# razor-pause!
 {{ add 4 5 }}
 @(4+5)
-# resume-razor!
+# razor-resume!
 
 {{ add 4 5 }}
 @(4+5)
@@ -24,15 +24,15 @@ Gives the following output:
 9
 9
 
-# pause-gotemplate!
+# gotemplate-pause!
 {{ add 4 5 }}
 @(4+5)
-# resume-gotemplate!
+# gotemplate-resume!
 
-# pause-razor!
+# razor-pause!
 9
 @(4+5)
-# resume-razor!
+# razor-resume!
 
 9
 9

--- a/docs_tests/advanced_features/pausing_processing.razor
+++ b/docs_tests/advanced_features/pausing_processing.razor
@@ -5,15 +5,15 @@ You can pause gotemplate's or razor processing with the following comments:
 {{ add 4 5 }}
 {{ add 4 5 }}
 
-# pause-gotemplate!
+# gotemplate-pause!
 {{ add 4 5 }}
 @(4+5)
-# resume-gotemplate!
+# gotemplate-resume!
 
-# pause-razor!
+# razor-pause!
 {{ add 4 5 }}
 @(4+5)
-# resume-razor!
+# razor-resume!
 
 {{ add 4 5 }}
 {{ add 4 5 }}
@@ -24,15 +24,15 @@ Gives the following output:
 9
 9
 
-# pause-gotemplate!
+# gotemplate-pause!
 {{ add 4 5 }}
 @(4+5)
-# resume-gotemplate!
+# gotemplate-resume!
 
-# pause-razor!
+# razor-pause!
 9
 @(4+5)
-# resume-razor!
+# razor-resume!
 
 9
 9

--- a/docs_tests/advanced_features/pausing_processing.rendered
+++ b/docs_tests/advanced_features/pausing_processing.rendered
@@ -5,15 +5,15 @@ You can pause gotemplate's or razor processing with the following comments:
 9
 9
 
-# pause-gotemplate!
+# gotemplate-pause!
 {{ add 4 5 }}
 @(4+5)
-# resume-gotemplate!
+# gotemplate-resume!
 
-# pause-razor!
+# razor-pause!
 9
 @(4+5)
-# resume-razor!
+# razor-resume!
 
 9
 9
@@ -24,15 +24,15 @@ Gives the following output:
 9
 9
 
-# pause-gotemplate!
+# gotemplate-pause!
 {{ add 4 5 }}
 @(4+5)
-# resume-gotemplate!
+# gotemplate-resume!
 
-# pause-razor!
+# razor-pause!
 9
 @(4+5)
-# resume-razor!
+# razor-resume!
 
 9
 9

--- a/template/template.go
+++ b/template/template.go
@@ -49,13 +49,13 @@ const (
 const (
 	noGoTemplate       = "no-gotemplate!"
 	noRazor            = "no-razor!"
-	explicitGoTemplate = "gotemplate!"
+	explicitGoTemplate = "force-gotemplate!"
 
-	pauseGoTemplate  = "pause-gotemplate!"
-	resumeGoTemplate = "resume-gotemplate!"
+	pauseGoTemplate  = "gotemplate-pause!"
+	resumeGoTemplate = "gotemplate-resume!"
 
-	pauseRazor  = "pause-razor!"
-	resumeRazor = "resume-razor!"
+	pauseRazor  = "razor-pause!"
+	resumeRazor = "razor-resume!"
 )
 
 // Common variables


### PR DESCRIPTION
To support earlier versions, we want to put a `# gotemplate-pause!` statement that will be handled whenever the gotemplate version is released
`# pause-gotemplate!` is interpreted as explicit gotemplate `# gotemplate!` in earlier version