### PR TITLE
Fix error when there was an @ in an expression string

### DIFF
--- a/docs_tests/basic_features/literals.razor
+++ b/docs_tests/basic_features/literals.razor
@@ -10,7 +10,7 @@ The result would be `<no value><no value>` unless you have defined:
 
 ```go
 {{- set $ "john" (data "doe = 123.45") }}
-{{- set $ "company" (data "com = {{ $.Math.Pi }}") }}
+{{- set $ "company" (data "com = @Math.Pi") }}
 ```
 
 In that case, the result of `{{ $.john.doe }}{{ $.company.com }}` will be `123.453.141592653589793`.

--- a/template/extra_runtime.go
+++ b/template/extra_runtime.go
@@ -393,11 +393,13 @@ func (t *Template) runTemplate(source string, context ...interface{}) (resultCon
 					return
 				}
 			} else {
-				razor, _ := t.applyRazor(fileContent)
-				source = string(razor)
+				source = string(fileContent)
 				filename = tryFile
 			}
 		}
+		razor, _ := t.applyRazor([]byte(source))
+		source = string(razor)
+
 		// There is no file named <source>, so we consider that <source> is the content
 		inline, e := t.New("inline").Parse(source)
 		if e != nil {

--- a/template/razor_expr.go
+++ b/template/razor_expr.go
@@ -17,7 +17,7 @@ func nodeValue(node ast.Node) (result string, err error) {
 	switch n := node.(type) {
 	case *ast.UnaryExpr:
 		var op, x string
-		if op, err = opName(n.Op); err != nil {
+		if op, err = operatorName(n.Op); err != nil {
 			return
 		}
 		if x, err = nodeValueInternal(n.X); err != nil {
@@ -30,7 +30,7 @@ func nodeValue(node ast.Node) (result string, err error) {
 		result = fmt.Sprintf("%s %s", op, x)
 	case *ast.BinaryExpr:
 		var op, x, y string
-		if op, err = opName(n.Op); err != nil {
+		if op, err = operatorName(n.Op); err != nil {
 			return
 		}
 		if x, err = nodeValueInternal(n.X); err != nil {
@@ -132,7 +132,7 @@ func nodeValue(node ast.Node) (result string, err error) {
 	return
 }
 
-var ops = map[string]string{
+var operators = map[string]string{
 	"==": "eq",
 	"!=": "ne",
 	"<":  "lt",
@@ -155,8 +155,8 @@ var ops = map[string]string{
 	"&^": "bclear",
 }
 
-func opName(token token.Token) (string, error) {
-	if name, ok := ops[token.String()]; ok {
+func operatorName(token token.Token) (string, error) {
+	if name, ok := operators[token.String()]; ok {
 		return name, nil
 	}
 	return "", fmt.Errorf("Unknown operator %v", token)
@@ -169,7 +169,6 @@ func nodeValueInternal(node ast.Node) (result string, err error) {
 		return
 	}
 
-	// if first, _ := collections.Split2(result, " "); !strings.HasPrefix(first, dotRep) || strings.Contains(first, funcCall) {
 	if first, _ := collections.Split2(result, " "); !(strings.HasPrefix(first, dotRep) && strings.Contains(first, funcCall)) {
 		result = fmt.Sprintf("(%s)", result)
 	}

--- a/template/razor_repl_expr.go
+++ b/template/razor_repl_expr.go
@@ -55,6 +55,9 @@ func expressionParserInternal(repl replacement, match string, skipError, interna
 
 		// We first protect strings declared in the expression
 		protected, includedStrings := String(expression).Protect()
+		for i := range includedStrings {
+			includedStrings[i] = includedStrings[i].Replace("@", literalAt)
+		}
 
 		// We transform the expression into a valid go statement
 		for k, v := range map[string]string{"$": stringRep, "range": rangeExpr, "default": defaultExpr, "func": funcExpr, "...": ellipsisRep, "type": typeExpr, "map": mapExpr} {
@@ -65,7 +68,7 @@ func expressionParserInternal(repl replacement, match string, skipError, interna
 			protected = protected.Replace(k, v)
 		}
 
-		for key, val := range ops {
+		for key, val := range operators {
 			protected = protected.Replace(" "+val+" ", key)
 		}
 		// We add support to partial slice

--- a/template/razor_test.go
+++ b/template/razor_test.go
@@ -311,6 +311,11 @@ func TestAssign(t *testing.T) {
 			`@{a.b.c} ÷= 2`,
 			`{{- set $a.b "c" (div $a.b.c 2) }}`,
 		},
+		{
+			"Assignment with @",
+			`@a := "How do you @handle this"`,
+			`{{- set $ "a" "How do you @handle this" }}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The @ should be replaced by a literal @ to ensure that it is not interpreted as a Razor expression.