### PR TITLE
Fix: Functions can now be added to a template without getting a new context

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -141,7 +141,7 @@ func (t *Template) TempFolder(folder string) *Template {
 	return t
 }
 
-// GetNewContext returns a distint context for each folder.
+// GetNewContext returns a distinct context for each folder.
 func (t *Template) GetNewContext(folder string, useCache bool) *Template {
 	folder = iif(folder != "", folder, t.folder).(string)
 	if context, found := t.children[folder]; useCache && found {
@@ -150,9 +150,10 @@ func (t *Template) GetNewContext(folder string, useCache bool) *Template {
 
 	newTemplate := Template(*t)
 	newTemplate.Template = template.New(folder)
+	newTemplate.addFunctions(t.functions)
+	newTemplate.addFunctions(t.aliases)
 	newTemplate.init(folder)
 	newTemplate.parent = t
-	newTemplate.addFunctions(t.aliases)
 	newTemplate.importTemplates(t)
 	newTemplate.options = make(OptionsSet)
 	if dict := t.Context(); dict.Len() > 0 {
@@ -249,7 +250,6 @@ func (t *Template) init(folder string) {
 		t.folder, _ = filepath.Abs(folder)
 	}
 	t.addFuncs()
-	t.Parse("")
 	t.children = make(map[string]*Template)
 	t.Delims(t.delimiters[0], t.delimiters[1])
 	t.setConstant(false, "\n", "NL", "CR", "NEWLINE")

--- a/template/template_handler.go
+++ b/template/template_handler.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/coveooss/gotemplate/v3/collections"
 	"github.com/coveooss/gotemplate/v3/utils"
 	"github.com/coveooss/multilogger/errors"
 	"github.com/fatih/color"
@@ -220,15 +221,14 @@ func (t *Template) processContentInternal(originalContent, source string, origin
 		}()
 	}
 
-	th.Template = t.GetNewContext(filepath.Dir(th.Filename), !cloneContext)
-	actualTemplate := th.Template.New(th.Filename)
-	th.Template.Template = actualTemplate
+	context := t.GetNewContext(filepath.Dir(th.Filename), true)
+	newTemplate := context.New(th.Filename)
 
 	if topCall {
-		actualTemplate.Option("missingkey=default")
+		newTemplate.Option("missingkey=default")
 	} else if !t.options[AcceptNoValue] {
 		// To help detect errors on second run, we enable the option to raise error on nil values
-		actualTemplate.Option("missingkey=error")
+		newTemplate.Option("missingkey=error")
 	}
 
 	func() {
@@ -236,7 +236,7 @@ func (t *Template) processContentInternal(originalContent, source string, origin
 		// call the parser without locking
 		templateMutex.Lock()
 		defer templateMutex.Unlock()
-		actualTemplate, err = actualTemplate.Parse(th.Code)
+		newTemplate, err = newTemplate.Parse(th.Code)
 	}()
 	if err != nil {
 		InternalLog.Debugf("%s(%d): Parsing error %v", th.Filename, th.Try, err)
@@ -244,7 +244,11 @@ func (t *Template) processContentInternal(originalContent, source string, origin
 	}
 
 	var out bytes.Buffer
-	if err = actualTemplate.Execute(&out, th.Template.context); err != nil {
+	workingContext := t.context
+	if cloneContext {
+		workingContext = collections.AsDictionary(workingContext).Clone()
+	}
+	if err = newTemplate.Execute(&out, workingContext); err != nil {
 		InternalLog.Debugf("%s(%d): Execution error %v", th.Filename, th.Try, err)
 		return th.Handler(err)
 	}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -119,3 +119,21 @@ func Test_templateWithErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestTemplateAddFunctions(t *testing.T) {
+	t.Parallel()
+
+	getValue := func() interface{} {
+		return "This Is My Value"
+	}
+
+	options := DefaultOptions()
+	options[StrictErrorCheck] = true
+	template, _ := NewTemplate(".", map[string]interface{}{}, "", options)
+	template.AddFunctions(map[string]interface{}{"getValue": getValue}, "Inline", nil)
+	_, ok := template.functions["getValue"]
+	assert.True(t, ok, "getValue is not defined")
+	result, err := template.ProcessContent("@getValue()", ".")
+	assert.Nil(t, err)
+	assert.Equal(t, "This Is My Value", result)
+}


### PR DESCRIPTION
Added functions are no longer wiped when creating a new context