### PR TITLE
Fix problem with assignment operators using expression

### DIFF
--- a/template/razor_repl_assign.go
+++ b/template/razor_repl_assign.go
@@ -39,25 +39,25 @@ func assignExpressionInternal(repl replacement, match string, acceptError bool) 
 	case "@{", "@$":
 		internal = strings.Contains(id, ".")
 	}
-	var err error
-	if expr, err = expressionParserInternal(exprRepl, expr, true, internal); err != nil && !acceptError {
-		return match
-	}
 
 	switch assign {
 	case ":=", "=":
 		break
 	default:
 		// This is an assignment operator (i.e. +=, /=, <<=, etc.)
-		if tp != "@{" {
-			value := map[string]string{"@": "$.", "@.": ".", "@$": "$"}[tp] + id
-			match = fmt.Sprintf("%[5]s%[1]s = %[2]s %[3]s %[4]s", id, value, assign[:len(assign)-1], expr, tp)
-		} else if acceptError {
-			match = fmt.Sprintf("@{%[1]s = $%[1]s %[2]s %[3]s}", id, assign[:len(assign)-1], expr)
+		operator := assign[:len(assign)-1]
+		assign = "="
+		if tp == "@{" {
+			expr = fmt.Sprintf("$%[1]s %[2]s (%[3]s)", id, operator, expr)
 		} else {
-			match = fmt.Sprintf("@{%[1]s} = $%[1]s %[2]s %[3]s", id, assign[:len(assign)-1], expr)
+			value := map[string]string{"@": "$.", "@.": ".", "@$": "$"}[tp] + id
+			expr = fmt.Sprintf("%[1]s %[2]s (%[3]s)", value, operator, expr)
 		}
-		return assignExpressionInternal(repl, match, acceptError)
+	}
+
+	var err error
+	if expr, err = expressionParserInternal(exprRepl, expr, true, internal); err != nil && !acceptError {
+		return match
 	}
 
 	if !global && !internal {

--- a/template/razor_test.go
+++ b/template/razor_test.go
@@ -288,8 +288,8 @@ func TestAssign(t *testing.T) {
 		},
 		{
 			"Assignment operator 6",
-			`@.a.b *= 4`,
-			`{{- assertWarning (not (isNil .a.b)) ".a.b does not exist, use := to declare new variable" }}{{- set .a "b" (mul .a.b 4) }}`,
+			`@.a.b *= 4*2`,
+			`{{- assertWarning (not (isNil .a.b)) ".a.b does not exist, use := to declare new variable" }}{{- set .a "b" (mul .a.b (mul 4 2)) }}`,
 		},
 		{
 			"Assignment operator 7",
@@ -305,6 +305,21 @@ func TestAssign(t *testing.T) {
 			"Assignment operator local sub",
 			`@{a.b.c} ÷= 2`,
 			`{{- set $a.b "c" (div $a.b.c 2) }}`,
+		},
+		{
+			"Assignment operator with expression",
+			`@{a} /= 2 * 3`,
+			`{{- $a = div $a (mul 2 3) }}`,
+		},
+		{
+			"Global assignment operator with expression",
+			`@a %= 2 / 3`,
+			`{{- assertWarning (not (isNil $.a)) "$.a does not exist, use := to declare new variable" }}{{- set $ "a" (mod $.a (div 2 3)) }}`,
+		},
+		{
+			"Assignment operator with index",
+			`@{a} += $text[3:]`,
+			`{{- $a = add $a (slice $text 3 -1) }}`,
 		},
 		{
 			"Assignment with @",


### PR DESCRIPTION
If we write an expression such as:
`@a += 2/3`

we expect to get:
`{{- assertWarning (not (isNil $.a)) "$.a does not exist, use := to declare new variable" }}{{- set $ "a" (add $.a (div 2 3)) }}`

But we got:
`{{ $.a }} = $.a + (div 2 3)`

Which is wrong.

The problem was that the assigned razor expression was converted to go template, then we added the value which resulted in a mixup of razor and go template syntax ...