### PR TITLE
Fix the bug where global variables set in extension where not available

### DIFF
--- a/docs_tests/advanced_features/functions.md
+++ b/docs_tests/advanced_features/functions.md
@@ -4,6 +4,10 @@
 
 The following file is evaluated: [!extensions.gte](!extensions.gte)
 
+## Variable set in extension are globally available
+
+The value of `@GlobalExtensionVariable` should be `I am set and I am global`.
+
 ## Calling functions
 
 ### Without arguments

--- a/docs_tests/advanced_features/functions.razor
+++ b/docs_tests/advanced_features/functions.razor
@@ -4,6 +4,10 @@
 
 The following file is evaluated: [!extensions.gte](!extensions.gte)
 
+## Variable set in extension are globally available
+
+The value of `{{ $.GlobalExtensionVariable }}` should be `I am set and I am global`.
+
 ## Calling functions
 
 ### Without arguments

--- a/docs_tests/advanced_features/functions.rendered
+++ b/docs_tests/advanced_features/functions.rendered
@@ -4,6 +4,10 @@
 
 The following file is evaluated: [!extensions.gte](!extensions.gte)
 
+## Variable set in extension are globally available
+
+The value of `I am set and I am global` should be `I am set and I am global`.
+
 ## Calling functions
 
 ### Without arguments

--- a/docs_tests/advanced_features/functions/!extensions.gte
+++ b/docs_tests/advanced_features/functions/!extensions.gte
@@ -36,3 +36,6 @@ Default configuration for christmas tree.
 Register the functions.
 @func("Fir", "template", "draw_fir", $firConfig)
 @func("ChristmasTree", "template", "draw_fir", $ctConfig)
+
+# Set global variable value
+@GlobalExtensionVariable := "I am set and I am global"

--- a/template/extra_runtime.go
+++ b/template/extra_runtime.go
@@ -388,9 +388,9 @@ func (t *Template) runTemplate(source string, args ...interface{}) (result, file
 	parentContext := t.userContext()
 	// Clone the current context to ensure that the sub template has a distinct set of values
 	t = t.GetNewContext("", false)
-	context := t.Context()
+	context := t.Context().Clone()
 	if context.Len() == 0 {
-		context.Set("CONTEXT", t.context)
+		context.Set("CONTEXT", context)
 	}
 	switch len(args) {
 	case 1:

--- a/template/template.go
+++ b/template/template.go
@@ -160,9 +160,6 @@ func (t *Template) GetNewContext(folder string, useCache bool) *Template {
 	newTemplate.parent = t
 	newTemplate.importTemplates(t)
 	newTemplate.options = make(OptionsSet)
-	if dict := t.Context(); dict.Len() > 0 {
-		newTemplate.context = dict.Clone()
-	}
 
 	// We duplicate the options because the new context may alter them afterwhile and
 	// it should not modify the original values.


### PR DESCRIPTION
Global variables set in gotemplate extension (.gte files) should be globally available.