### PR TITLE
Fix the problem where we detect unrelated errors

### DIFF
--- a/template/extra_data.go
+++ b/template/extra_data.go
@@ -269,7 +269,7 @@ func (t *Template) addDataFuncs() {
 func toChar(value interface{}) (r interface{}, err error) {
 	defer func() { err = trapError(err, recover()) }()
 	return process(value, func(a interface{}) interface{} {
-		return string(toInt(a))
+		return string(byte(toInt(a)))
 	})
 }
 

--- a/template/template_error_handler.go
+++ b/template/template_error_handler.go
@@ -139,7 +139,7 @@ func (t errorHandler) Handler(err error) (string, bool, error) {
 			} else {
 				lines[faultyLine] = currentLine.Replace(context.Str(), runError).Str()
 			}
-		} else if errText != noValueError {
+		} else {
 			logMessage = fmt.Sprintf("Parsing error: %s", err)
 			lines[faultyLine] = fmt.Sprintf("ERROR %s", errText)
 		}
@@ -162,7 +162,7 @@ func (t errorHandler) Handler(err error) (string, bool, error) {
 			}
 			result, changed, err2 := t.processContentInternal(newCode, t.Filename, t.Lines, t.Try+1, false, nil)
 			if err2 != nil {
-				if err != nil && errText != noValueError {
+				if err != nil {
 					if err.Error() == err2.Error() {
 						// TODO See: https://github.com/golang/go/issues/27319
 						err = fmt.Errorf("%v\n%s", err, color.HiRedString("Unable to continue processing to check for further errors"))

--- a/template/template_error_handler_test.go
+++ b/template/template_error_handler_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -39,6 +40,36 @@ func TestTemplateErrorHandling(t *testing.T) {
 				assert.NoError(t, err)
 			} else {
 				assert.Equal(t, tt.errCount, strings.Count(err.Error(), tt.err))
+			}
+		})
+	}
+}
+
+func Test_templateWithErrors(t *testing.T) {
+	t.Parallel()
+
+	template, _ := NewTemplate(".", nil, "", nil)
+	template.SetOption(StrictErrorCheck, true)
+	tests := []struct {
+		name    string
+		content string
+		err     error
+	}{
+		{"Empty template", "", nil},
+		{"Non closed brace", "{{", fmt.Errorf("Non closed brace:1: unexpected unclosed action in command in: {{")},
+		{"Non opened brace", "}}", nil},
+		{"Undefined value", "@value", fmt.Errorf("Undefined value:1: contains undefined value(s) in: @value")},
+		{"2 Undefined values", "@(value1 + value2)", fmt.Errorf("2 Undefined values:1: contains undefined value(s) in: @(value1 + value2)")},
+		{"Several errors", "@(value1)\n@non_Existing_Func()\n{{\n", fmt.Errorf("Several errors:2: function \"non_Existing_Func\" not defined in: @non_Existing_Func()\nSeveral errors:3: unexpected unclosed action in command in: {{\nSeveral errors:1: contains undefined value(s) in: @(value1)")},
+		{"undefined variable", "@(value_non_existing)", fmt.Errorf("undefined variable:1: contains undefined value(s) in: @(value_non_existing)")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := template.ProcessContent(tt.content, tt.name); err != tt.err {
+				if err != nil && tt.err != nil && err.Error() == tt.err.Error() {
+					return
+				}
+				t.Errorf("ProcessContent()=\n%v\n\nWant:\n%v", err, tt.err)
 			}
 		})
 	}

--- a/template/template_error_handler_test.go
+++ b/template/template_error_handler_test.go
@@ -1,0 +1,45 @@
+package template
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplateErrorHandling(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		code     string
+		err      string
+		errCount int
+	}{
+		{
+			"Undefined", `@value`,
+			noValueError, 1,
+		},
+		{
+			"Undefined with nil test", "@value@if(missing) whatever;",
+			noValueError, 1,
+		},
+		{
+			"2 Undefined with nil test", `
+			   @value
+			   @if(missing) whatever;
+			   @otherValue
+			`,
+			noValueError, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			template := MustNewTemplate(".", nil, "", DefaultOptions().Set(StrictErrorCheck).Unset(AcceptNoValue))
+			_, err := template.ProcessContent(tt.code, "")
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, tt.errCount, strings.Count(err.Error(), tt.err))
+			}
+		})
+	}
+}

--- a/template/template_handler.go
+++ b/template/template_handler.go
@@ -223,13 +223,7 @@ func (t *Template) processContentInternal(originalContent, source string, origin
 
 	context := t.GetNewContext(filepath.Dir(th.Filename), true)
 	newTemplate := context.New(th.Filename)
-
-	if topCall {
-		newTemplate.Option("missingkey=default")
-	} else if !t.options[AcceptNoValue] {
-		// To help detect errors on second run, we enable the option to raise error on nil values
-		newTemplate.Option("missingkey=error")
-	}
+	newTemplate.Option("missingkey=default")
 
 	func() {
 		// Here, we invoke the parser within a pseudo func because we cannot
@@ -256,15 +250,12 @@ func (t *Template) processContentInternal(originalContent, source string, origin
 
 	changed = result != originalContent
 
-	if topCall && !t.options[AcceptNoValue] {
+	if !t.options[AcceptNoValue] {
 		// Detect possible <no value> or <nil> that could be generated
 		if pos := strings.Index(strings.Replace(result, nilValue, noValue, -1), noValue); pos >= 0 {
 			line := len(strings.Split(result[:pos], "\n"))
 			return th.Handler(fmt.Errorf("template: %s:%d: %s", th.Filename, line, noValueError))
 		}
-	}
-
-	if !t.options[AcceptNoValue] {
 		// We restore the existing no value if any
 		result = strings.Replace(result, noValueRepl, noValue, -1)
 		result = strings.Replace(result, nilValueRepl, nilValue, -1)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,7 +1,6 @@
 package template
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -86,36 +85,6 @@ func TestTemplateFilesOverwrite(t *testing.T) {
 			result, err := ioutil.ReadFile(tempfile.Name())
 			assert.Nil(t, err)
 			assert.Equal(t, tt.result, string(result))
-		})
-	}
-}
-
-func Test_templateWithErrors(t *testing.T) {
-	t.Parallel()
-
-	template, _ := NewTemplate(".", nil, "", nil)
-	template.SetOption(StrictErrorCheck, true)
-	tests := []struct {
-		name    string
-		content string
-		err     error
-	}{
-		{"Empty template", "", nil},
-		{"Non closed brace", "{{", fmt.Errorf("Non closed brace:1: unexpected unclosed action in command in: {{")},
-		{"Non opened brace", "}}", nil},
-		{"Undefined value", "@value", fmt.Errorf("Undefined value:1:4: Undefined value value in: @value")},
-		{"2 Undefined values", "@(value1 + value2)", fmt.Errorf("2 Undefined values:1:8: Undefined value value1 in: @(value1 + value2)\n2 Undefined values:1:21: Undefined value value2 in: @(value1 + value2)")},
-		{"Several errors", "@(value1)\n@non_Existing_Func()\n{{\n", fmt.Errorf("Several errors:2: function \"non_Existing_Func\" not defined in: @non_Existing_Func()\nSeveral errors:3: unexpected unclosed action in command in: {{\nSeveral errors:1:4: Undefined value value1 in: @(value1)")},
-		{"undefined variable", "@(value_non_existing)", fmt.Errorf("undefined variable:1:4: Undefined value value_non_existing in: @(value_non_existing)")},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if _, err := template.ProcessContent(tt.content, tt.name); err != tt.err {
-				if err != nil && tt.err != nil && err.Error() == tt.err.Error() {
-					return
-				}
-				t.Errorf("ProcessContent()=\n%v\n\nWant:\n%v", err, tt.err)
-			}
 		})
 	}
 }


### PR DESCRIPTION
No longer switch the error detection to strict mode after discovering one error. That generates error that should not be considered as error otherwise (ex. a if statement with a non existing variable).