### PR TITLE
Fix description not rendering in functions doc

### DIFF
--- a/render-doc
+++ b/render-doc
@@ -65,9 +65,9 @@ rsync -av docs_tests/ $DOC_FOLDER -r
             @<println("func", include("trim", dict("text", stripColor($func.Signature))))
             @-print("```")
             @-if ($func.Description)
-                @<print("\n<pre>")
+                @<print("\n```")
                 @<template("trim", dict("text", $func.Description))
-                @<;</pre>
+                @<;```
             @-else
                 @-warning($func.Name, "does not have description")
             @-endif


### PR DESCRIPTION
Jira DT-4201

I'm not sure when this started to happen but it seems like this was all caused because the `render-doc` script put the description in `<pre>` tags which hugo did not want to render correctly. Switching them to markdown code blocks does the trick.