### PR TITLE
Don't run templating on results of command in exec function

### DIFF
--- a/template/extra_runtime.go
+++ b/template/extra_runtime.go
@@ -377,14 +377,20 @@ func (t *Template) tryConvert(value string) interface{} {
 }
 
 // Execute the command (command could be a file, a template or a script) and convert its result as data if possible
-func (t *Template) exec(command string, args ...interface{}) (result interface{}, err error) {
-	if result, err = t.run(command, args...); err == nil {
-		if result == nil {
-			return
-		}
-		result = t.tryConvert(result.(string))
+func (t *Template) exec(command string, args ...interface{}) (interface{}, error) {
+	commandOutput, err := t.run(command, args...)
+	if err != nil || commandOutput == nil {
+		return commandOutput, err
 	}
-	return
+
+	var parsedOutput interface{}
+	err = collections.ConvertData(commandOutput.(string), &parsedOutput)
+
+	if err == nil {
+		return parsedOutput, nil
+	} else {
+		return commandOutput, nil
+	}
 }
 
 func (t *Template) runTemplate(source string, args ...interface{}) (result, filename string, err error) {


### PR DESCRIPTION
Jira: DT-4200

Before this PR, the `exec` function either when invoked directly or when used through the `func` function, would try to template the output of the underlying command. This can lead to some nasty surprises for devs who end up with code that doesn't behave as they expect.