### PR TITLE
update dependabot config to match other go projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,29 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 99
-  reviewers:
-  - jocgir
-  - dblanchette
-  ignore:
-  - dependency-name: github.com/sirupsen/logrus
-    versions:
-    - 1.8.0
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 20
+    reviewers:
+      - dblanchette
+      - dlevesque-coveo
+      - dotboris
+      - jocgir
+      - jonapich
+      - pballandras
+      - wtrep
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: weekly
+    reviewers:
+      - dblanchette
+      - dlevesque-coveo
+      - dotboris
+      - jocgir
+      - jonapich
+      - pballandras
+      - wtrep


### PR DESCRIPTION
The changes here are:

- Add the whole team as reviewers
- Reduce the number of open pull requests to 20
- Add updates for github actions

Note to reviewers:
- The indentation changed a bit, hiding whitespaces will help with the review here.
- The removed dependency version has been upgraded past and the ignore is no longer required.