### PR TITLE
CSEC-18897 bump v3.8 to 3.9 via specific hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Setup Hugo
         if: github.ref == 'refs/heads/master'
-        uses: peaceiris/actions-hugo@v2.5.0
+        uses: peaceiris/actions-hugo@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7
         with:
           hugo-version: "0.82.0"
           extended: true


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CSEC-18897

Bumping so specific hash to comply with CSEC's GHA policies