### PR TITLE
Csec 18897 migrate peaceiris actions gh pages to hash specific version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Setup Hugo
         if: github.ref == 'refs/heads/master'
-        uses: peaceiris/actions-hugo@v2.5.0
+        uses: peaceiris/actions-hugo@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7
         with:
           hugo-version: "0.82.0"
           extended: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Setup Hugo
         if: github.ref == 'refs/heads/master'
-        uses: peaceiris/actions-hugo@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7
+        uses: peaceiris/actions-hugo@v2.5.0
         with:
           hugo-version: "0.82.0"
           extended: true
@@ -47,7 +47,7 @@ jobs:
 
       - name: Deploy Documentation
         if: github.ref == 'refs/heads/master'
-        uses: peaceiris/actions-gh-pages@v3.8.0
+        uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7
         with:
           allow_empty_commit: false
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}


### PR DESCRIPTION
Update peaceiris action to 3.9 via specific hash to comply with CSEC's GHA policy