### PR TITLE
CSEC-18901 change v2.5.0 to it's release hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Setup Hugo
         if: github.ref == 'refs/heads/master'
-        uses: peaceiris/actions-hugo@v2.5.0
+        uses: peaceiris/actions-hugo@c03b5dbed22245418539b65eb9a3b1d5fdd9a0a6
         with:
           hugo-version: "0.82.0"
           extended: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2.5.0
+        uses: peaceiris/actions-hugo@c03b5dbed22245418539b65eb9a3b1d5fdd9a0a6
         with:
           hugo-version: "0.82.0"
           extended: true


### PR DESCRIPTION
Changing the v2.5.0 to it's release hash to comply with CSEC's GHA policy