### PR TITLE
fix detection of terraform .tf.json file

### DIFF
--- a/utils/terraform.go
+++ b/utils/terraform.go
@@ -11,12 +11,12 @@ import (
 
 // IsTerraformFile check if the file extension matches on of the terraform file extension
 func IsTerraformFile(file string) bool {
-	switch filepath.Ext(file) {
-	case ".tf", ".tf.json", ".tfvars":
-		return true
-	default:
-		return false
+	for _, ext := range []string{".tf", ".tf.json", ".tfvars"} {
+		if strings.HasSuffix(file, ext) {
+			return true
+		}
 	}
+	return false
 }
 
 // TerraformFormat applies terraform fmt on

--- a/utils/terraform_test.go
+++ b/utils/terraform_test.go
@@ -1,0 +1,40 @@
+package utils
+
+import "testing"
+
+func TestIsTerraformFile(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: ".tf file",
+			path: "somefile.tf",
+			want: true,
+		},
+		{
+			name: ".tf.json file",
+			path: "somefile.tf.json",
+			want: true,
+		},
+		{
+			name: ".tfvars file",
+			path: "somefile.tfvars",
+			want: true,
+		},
+		{
+			name: ".json file",
+			path: "somefile.json",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTerraformFile(tt.path); got != tt.want {
+				t.Errorf("IsTerraformFile(%s) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
By file extension, it is incorrect to say that a file with a suffix `.tf.json` is a terraform file, since the extension for such a file is `json`.
https://pkg.go.dev/path/filepath#example-Ext