### PR TITLE
Migrate goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,15 +20,17 @@ universal_binaries:
 # Archive customization
 archives:
   - format: zip
-
-    replacements:
-      amd64: 64-bits
-      darwin: macOS
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- if eq .Os "darwin" }}macOS_
+      {{- else }}{{ .Os }}_{{ end }}
+      {{- if eq .Arch "amd64" }}64-bits
+      {{- else }}{{ .Arch }}{{ end }}
 
     files:
       - nothing.*
 
 # GitHub release customization
 release:
-  draft: true
-  prerelease: true
+  prerelease: auto


### PR DESCRIPTION
This fixes the release process. We moved a major version without realizing in #222 