### PR TITLE
chore: use os and io instead of deprecated io.ioutil

### DIFF
--- a/collections/convert_data.go
+++ b/collections/convert_data.go
@@ -2,7 +2,6 @@ package collections
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
@@ -66,7 +65,7 @@ func ConvertData(data string, out interface{}) (err error) {
 // LoadData returns a go representation of the supplied file name (YAML, JSON or HCL)
 func LoadData(filename string, out interface{}) (err error) {
 	var content []byte
-	if content, err = ioutil.ReadFile(filename); err == nil {
+	if content, err = os.ReadFile(filename); err == nil {
 		return ConvertData(string(content), out)
 	}
 	return

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -2,7 +2,7 @@ package hcl
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"reflect"
 
 	"github.com/coveooss/gotemplate/v3/collections"
@@ -70,7 +70,7 @@ func Unmarshal(bs []byte, out interface{}) (err error) {
 // Load loads hcl file into variable
 func Load(filename string) (result interface{}, err error) {
 	var content []byte
-	if content, err = ioutil.ReadFile(filename); err == nil {
+	if content, err = os.ReadFile(filename); err == nil {
 		err = Unmarshal(content, &result)
 	}
 	return

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -27,7 +26,7 @@ import (
 
 // Version is initialized at build time through -ldflags "-X main.Version=<version number>"
 var version = "2.7.4"
-var tempFolder = errors.Must(ioutil.TempDir("", "gotemplate-")).(string)
+var tempFolder = errors.Must(os.MkdirTemp("", "gotemplate-")).(string)
 
 const (
 	envDisableStdinCheck = "GOTEMPLATE_NO_STDIN"

--- a/main_test.go
+++ b/main_test.go
@@ -10,11 +10,10 @@ import (
 )
 
 func TestCli(t *testing.T) {
-	variableTempDir, err := os.MkdirTemp("", "gotemplate-test-variable")
-	assert.NoError(t, err)
-	defer os.RemoveAll(variableTempDir)
+	variableTempDir := t.TempDir()
+
 	variableFile := path.Join(variableTempDir, "test.variables")
-	err = os.WriteFile(variableFile, []byte("testInt = 5\ntestString = \"hello\"\ntestBool = true"), 0644)
+	err := os.WriteFile(variableFile, []byte("testInt = 5\ntestString = \"hello\"\ntestBool = true"), 0644)
 	assert.NoError(t, err)
 
 	tests := []struct {
@@ -154,10 +153,8 @@ func TestCli(t *testing.T) {
 
 			if tt.template != "" {
 				// Create template
-				tempDir, err = os.MkdirTemp("", "gotemplate-test")
-				assert.NoError(t, err)
+				tempDir = t.TempDir()
 				os.Chdir(tempDir)
-				defer os.RemoveAll(tempDir)
 				templateFile := path.Join(tempDir, "test.template")
 				err = os.WriteFile(templateFile, []byte(tt.template), 0644)
 				assert.NoError(t, err)

--- a/template/extra_git_test.go
+++ b/template/extra_git_test.go
@@ -1,7 +1,6 @@
 package template
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,8 +49,7 @@ func TestOrigin(t *testing.T) {
 }
 
 func initTestRepository(t *testing.T) (string, *git.Repository, *object.Commit) {
-	path, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	path := t.TempDir()
 
 	// Init the repository
 	repo, err := git.PlainInit(path, false)
@@ -61,7 +59,7 @@ func initTestRepository(t *testing.T) (string, *git.Repository, *object.Commit) 
 
 	// Create a file to commit
 	filename := filepath.Join(path, "example-git-file")
-	err = ioutil.WriteFile(filename, []byte("hello world!"), 0644)
+	err = os.WriteFile(filename, []byte("hello world!"), 0644)
 	assert.NoError(t, err)
 	_, err = worktree.Add("example-git-file")
 	assert.NoError(t, err)

--- a/template/extra_os.go
+++ b/template/extra_os.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -194,7 +193,7 @@ func saveToFile(filename string, object interface{}) (string, error) {
 			return "", err
 		}
 	}
-	return "", ioutil.WriteFile(filename, []byte(fmt.Sprint(object)), 0644)
+	return "", os.WriteFile(filename, []byte(fmt.Sprint(object)), 0644)
 }
 
 func username() string {

--- a/template/extra_runtime.go
+++ b/template/extra_runtime.go
@@ -3,7 +3,6 @@ package template
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -467,7 +466,7 @@ func (t *Template) runTemplate(source string, args ...interface{}) (result, file
 			if !path.IsAbs(tryFile) {
 				tryFile = path.Join(t.folder, tryFile)
 			}
-			if fileContent, e := ioutil.ReadFile(tryFile); e != nil {
+			if fileContent, e := os.ReadFile(tryFile); e != nil {
 				if _, ok := e.(*os.PathError); !ok {
 					err = e
 					return

--- a/template/razor_test.go
+++ b/template/razor_test.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -43,7 +42,7 @@ func TestTemplate_applyRazor(t *testing.T) {
 
 	template.options[AcceptNoValue] = true
 
-	load := func(path string) []byte { return must(ioutil.ReadFile(path)).([]byte) }
+	load := func(path string) []byte { return must(os.ReadFile(path)).([]byte) }
 
 	tests := make([]test, 0, len(files))
 	for _, file := range files {

--- a/template/template.go
+++ b/template/template.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -229,7 +228,7 @@ func (t *Template) initExtension() {
 		// We just load all the template files available to ensure that all template definition are loaded
 		// We do not use ParseFiles because it names the template with the base name of the file
 		// which result in overriding templates with the same base name in different folders.
-		content := string(must(ioutil.ReadFile(file)).([]byte))
+		content := string(must(os.ReadFile(file)).([]byte))
 
 		// We execute the content, but we ignore errors. The goal is only to register the sub templates and aliases properly
 		// We also do not ask to clone the context as we wish to let extension to be able to alter the supplied context

--- a/template/template_error_handler.go
+++ b/template/template_error_handler.go
@@ -2,7 +2,7 @@ package template
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -56,7 +56,7 @@ func (t errorHandler) Handler(err error) (string, bool, error) {
 			// An error occurred in an included external template file, we cannot try to recuperate
 			// and try to find further errors, so we just return the error.
 			var line string
-			if fileContent, err := ioutil.ReadFile(matches[tagFile]); err != nil {
+			if fileContent, err := os.ReadFile(matches[tagFile]); err != nil {
 				line = fmt.Sprintf("Unable to read file: %v", err)
 			} else {
 				line = String(fileContent).Lines()[toInt(matches[tagLine])-1].Str()

--- a/template/template_handler.go
+++ b/template/template_handler.go
@@ -3,7 +3,6 @@ package template
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -45,7 +44,7 @@ func (t *Template) processTemplate(template, sourceFolder, targetFolder string, 
 	isCode := t.IsCode(template)
 	var content string
 
-	if fileContent, fileError := ioutil.ReadFile(template); fileError == nil {
+	if fileContent, fileError := os.ReadFile(template); fileError == nil {
 		content = string(fileContent)
 		isCode = false
 	} else if isCode {
@@ -125,7 +124,7 @@ func (t *Template) processTemplate(template, sourceFolder, targetFolder string, 
 		mode = 0755
 	}
 
-	if err = ioutil.WriteFile(resultFile, []byte(result), mode); err != nil {
+	if err = os.WriteFile(resultFile, []byte(result), mode); err != nil {
 		return
 	}
 

--- a/template/template_process.go
+++ b/template/template_process.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,14 +53,14 @@ func (t *Template) ProcessTemplates(sourceFolder, targetFolder string, templates
 func (t *Template) printResult(source, target, result string) (err error) {
 	if utils.IsTerraformFile(target) {
 		base := filepath.Base(target)
-		tempFolder := must(ioutil.TempDir(t.tempFolder, base)).(string)
+		tempFolder := must(os.CreateTemp(t.tempFolder, base)).(string)
 		tempFile := filepath.Join(tempFolder, base)
-		err = ioutil.WriteFile(tempFile, []byte(result), 0644)
+		err = os.WriteFile(tempFile, []byte(result), 0644)
 		if err != nil {
 			return
 		}
 		err = utils.TerraformFormat(tempFile)
-		bytes := must(ioutil.ReadFile(tempFile)).([]byte)
+		bytes := must(os.ReadFile(tempFile)).([]byte)
 		result = string(bytes)
 	}
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,7 +1,6 @@
 package template
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -71,7 +70,7 @@ func TestTemplateFilesOverwrite(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			tempfile, err := ioutil.TempFile("", "")
+			tempfile, err := os.CreateTemp("", "")
 			assert.Nil(t, err)
 			defer os.Remove(tempfile.Name())
 
@@ -82,7 +81,7 @@ func TestTemplateFilesOverwrite(t *testing.T) {
 			template.SetOption(Overwrite, true)
 			template.ProcessTemplates("", "", tempfile.Name())
 
-			result, err := ioutil.ReadFile(tempfile.Name())
+			result, err := os.ReadFile(tempfile.Name())
 			assert.Nil(t, err)
 			assert.Equal(t, tt.result, string(result))
 		})

--- a/utilities.go
+++ b/utilities.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -34,7 +34,7 @@ func readStdin() string {
 	if stdinContent != "" {
 		return stdinContent
 	}
-	stdinContent = string(must(ioutil.ReadAll(os.Stdin)).([]byte))
+	stdinContent = string(must(io.ReadAll(os.Stdin)).([]byte))
 	return stdinContent
 }
 

--- a/utils/exec.go
+++ b/utils/exec.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -34,7 +33,7 @@ func ScriptParts(content string) (program, subprogram, source string) {
 
 // GetCommandFromFile returns an exec.Cmd structure to run the supplied script file
 func GetCommandFromFile(filename string, args ...interface{}) (cmd *exec.Cmd, err error) {
-	script, err := ioutil.ReadFile(filename)
+	script, err := os.ReadFile(filename)
 	if err != nil {
 		return
 	}
@@ -94,7 +93,7 @@ func IsCommand(command string) bool {
 
 func saveTempFile(content string, args ...interface{}) (cmd *exec.Cmd, fileName string, err error) {
 	var temp *os.File
-	if temp, err = ioutil.TempFile("", "exec_"); err != nil {
+	if temp, err = os.CreateTemp("", "exec_"); err != nil {
 		return
 	}
 


### PR DESCRIPTION
In go v1.16 the `io/ioutil` package is [deprecated](https://go.dev/doc/go1.16#ioutil).