### PR TITLE
Action Go-Releaser deprecated the flag --rm-dist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a minor change to the `jobs:` section in the `.github/workflows/build.yml` file. The change updates the arguments passed to the `goreleaser` distribution.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L54-R54): Modified the `args` parameter from `release --rm-dist` to `release --clean`.It has been replaced by --clean
