### PR TITLE
Fix goreleaser-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run GoReleaser
         if: github.ref != 'refs/heads/master'
-        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yml` file. The change updates the `uses` statement for the GoReleaser action to use a more readable version reference.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L27-R27): Updated `goreleaser/goreleaser-action` to use `@v6` instead of a specific commit hash for better readability and maintainability.Dt 7256
