### PR TITLE
Revert the goreleaser-action to last approved digest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run GoReleaser
         if: github.ref != 'refs/heads/master'
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yml` file. The change updates the version of the `goreleaser` action used in the workflow.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L27-R27): Updated the `goreleaser` action to use a specific commit hash `7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8` instead of the version `v6`.