### PR TITLE
perf: Decrease compute time when using runtime features [DT-7499]

### DIFF
--- a/template/extra_runtime.go
+++ b/template/extra_runtime.go
@@ -446,7 +446,7 @@ func optimizedRunTemplate(t *Template, withClone bool, source string, args ...in
 		parentContext = t.cloneUserContext()
 		context = t.context.(collections.IDictionary)
 
-		context.Set("_", t.cloneUserContext())
+		context.Set("_", parentContext)
 
 		if context.Len() == 0 {
 			context.Set("CONTEXT", context)

--- a/template/extra_runtime_test.go
+++ b/template/extra_runtime_test.go
@@ -35,23 +35,30 @@ func TestRuntime(t *testing.T) {
 		},
 		{
 			name: "Get context",
-			content: `@define("func")
-			@base = 2
-			@-context()
+			content: `
+			@-define("func")
+				@base = 2
+				@-println("base =", base)
+				@-println("ARGS =", ARGS)
+				@-println("_.base =", _.base)
 			@-end
+
 			@-include("func", 1, 2, 3)
-			@-context()`,
-			result: `{"ARGS":[1,2,3],"_":{"base":1},"base":2}{"base":1}`,
+			@--println("base =", base)
+			`,
+			result: "base = 2\nARGS = [1,2,3]\n_.base = 1\nbase = 1\n",
 		},
 		{
 			name: "Override parent value",
-			content: `@define("func")
-			@-println("base =", base)
-			@-println("_.base =", _.base)
+			content: `
+			@-define("func")
+				@-println("base =", base)
+				@-println("_.base =", _.base)
 			@-end
 			@-include("func", data("base=over"))`,
 			result: "base = over\n_.base = 1\n",
-		}}
+		},
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			template := MustNewTemplate(".", nil, "", nil)


### PR DESCRIPTION
| branch | `main` | `feature/dt-7499-optimizeruntemplate` |
|--------|--------|--------|
| **average execution time** | 85,000ms | 1,500ms |

---
- All tests were done using this file with the command `gotemplate -i terraform.tfvars test.gt` :
```
##@ test.gt


@warning(Math.Pi)
@define("func")
    @info("called with:", ARGS)
    @info("Here's the current branch:", currentBranch("."), "...and pi: ", Math.Pi)
@end 
{{- set $ "region" "us-east-1" }}
{{- $re := reCompile (printf (`(%s-.+) \(.+\)`) "Dev") }}
  {{- $all_subnets := dict }}
  {{- $describeSubnets := printf "aws ec2 describe-subnets --region %s" $.region }}
  {{ warning "FILE_B.gt --- Executing: " $describeSubnets }}
  {{ range $subnet := (exec $describeSubnets).Subnets }}
    {{ range .Tags }}
      @-include("func", "pi?", Math.Pi)
      {{ if and (eq .Key "Name") ($re.MatchString .Value) }}
        {{/* The name matches the pattern used for v2 subnets */}}
        {{- $name := $re.ReplaceAllString .Value "$1" }}
        {{ warning "name: " $name }}
        {{ set $all_subnets $name (ellipsis "append" (get $all_subnets $name list) $subnet.Tags) }}
      {{ end }}
    {{ end }}
  {{ end }}
  {{ warning "Ouf, it has been short ... or is it?" }}

/*
  {{ $all_subnets }}
*/
{{ warning "route tables: " $.infra_route_tables }}
{{- set $ "subnets" (slice .infra_subnets.applications.all 0) }}
{{ warning "subnets: " $.subnets }}


{{- $all_countries := dict }}
{{ range $region := $.global_regions }}
  {{ range .countries }}
    {{ set $all_countries .flag (ellipsis "append" (get $all_countries .flag list) (values $region.countries)) }}
     @-include("func", .flag)
  {{ end }}
{{ end }}


{{ warning "countries: " $all_countries }}

```